### PR TITLE
Fix mkdocs dependency constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs==1.6.0
+mkdocs==1.5.3
 mkdocs-material==9.5.18


### PR DESCRIPTION
## Summary
- align the mkdocs requirement with the version supported by mkdocs-material to resolve installation conflicts

## Testing
- `python -m pip install -r requirements.txt` *(fails: blocked from downloading packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6124f9ddc832d8ed75e953f672549