### PR TITLE
Ensure support link renders in footer

### DIFF
--- a/assets/styles/custom.css
+++ b/assets/styles/custom.css
@@ -31,3 +31,14 @@
     left: -2rem;
   }
 }
+
+.md-footer-support {
+  text-align: center;
+  padding: 0.75rem 0;
+  font-size: 0.85rem;
+}
+
+.md-footer-support a {
+  color: inherit;
+  text-decoration: underline;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,6 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/
       name: GitHub
-  footer: |
-    Need support using the cookbook? Visit <a href="https://support.playrugbyleague.com" target="_blank" rel="noopener">support.playrugbyleague.com</a>.
+  footer: Need support using the cookbook? Visit <a href="https://support.playrugbyleague.com" target="_blank" rel="noopener">support.playrugbyleague.com</a>.
 extra_css:
   - assets/styles/custom.css

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -1,0 +1,58 @@
+<footer class="md-footer">
+  {% if "navigation.footer" in features %}
+    {% if page.previous_page or page.next_page %}
+      {% if page.meta and page.meta.hide %}
+        {% set hidden = "hidden" if "footer" in page.meta.hide %}
+      {% endif %}
+      <nav class="md-footer__inner md-grid" aria-label="{{ lang.t('footer') }}" {{ hidden }}>
+        {% if page.previous_page %}
+          {% set direction = lang.t('footer.previous') %}
+          <a href="{{ page.previous_page.url | url }}" class="md-footer__link md-footer__link--prev" aria-label="{{ direction }}: {{ page.previous_page.title | e }}">
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.previous or 'material/arrow-left' %}
+              {% include '.icons/' ~ icon ~ '.svg' %}
+            </div>
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                {{ direction }}
+              </span>
+              <div class="md-ellipsis">
+                {{ page.previous_page.title }}
+              </div>
+            </div>
+          </a>
+        {% endif %}
+        {% if page.next_page %}
+          {% set direction = lang.t('footer.next') %}
+          <a href="{{ page.next_page.url | url }}" class="md-footer__link md-footer__link--next" aria-label="{{ direction }}: {{ page.next_page.title | e }}">
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                {{ direction }}
+              </span>
+              <div class="md-ellipsis">
+                {{ page.next_page.title }}
+              </div>
+            </div>
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.next or 'material/arrow-right' %}
+              {% include '.icons/' ~ icon ~ '.svg' %}
+            </div>
+          </a>
+        {% endif %}
+      </nav>
+    {% endif %}
+  {% endif %}
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+      {% include 'partials/copyright.html' %}
+      {% if config.extra.social %}
+        {% include 'partials/social.html' %}
+      {% endif %}
+    </div>
+    {% if config.extra.footer %}
+      <div class="md-footer-support">
+        {{ config.extra.footer | safe }}
+      </div>
+    {% endif %}
+  </div>
+</footer>


### PR DESCRIPTION
## Summary
- add a custom Material footer partial that renders the configured support link
- style the footer support message for readability and visual alignment

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68e616d807d4832da8e44bf193f0305a